### PR TITLE
automatically gain the data in telescope action

### DIFF
--- a/src/services/BotGainResources.ts
+++ b/src/services/BotGainResources.ts
@@ -71,7 +71,9 @@ export default class BotGainResources {
       case Action.TELESCOPE:
         if (techType === TechType.TELESCOPE) {
           this.actionTechTelescope.value -= 1
+          this.actionData.value += 1
         }
+        this.actionData.value += action.scanSector.length
         break
       case Action.ANALYZE:
         this.actionVP.value += action.victoryPoints


### PR DESCRIPTION
This pull request makes the telescope action gain the data cube automatically, which I find myself forget a lot using the helper.

I am not familar with JS, so please check whether what I was doing is correct. The local test seems to doing the right thing.