### PR TITLE
Rival Passing: Show 1 gained progress step in the box

### DIFF
--- a/src/services/BotActionResources.ts
+++ b/src/services/BotActionResources.ts
@@ -67,9 +67,6 @@ export default class BotActionResources {
           this.actionProgress.value += 1
         }
         break
-      case Action.PASS:
-        this.actionProgress.value += 1
-        break
       case Action.SPECIES_SPECIAL_ACTION:
         switch (alienSpecies) {
           case AlienSpecies.MASCAMITES:

--- a/src/util/getInitialBotGameBoardResources.ts
+++ b/src/util/getInitialBotGameBoardResources.ts
@@ -21,5 +21,9 @@ export default function getInitialBotGameBoardResources(action: CardAction, tech
     }
     return { data }
   }
+  else if (action.action == Action.PASS) {
+    // bot draws a card and gains 1 progress
+    return { progressSingleStep: 1 }
+  }
   return {}
 }

--- a/src/views/RoundTurnBot.vue
+++ b/src/views/RoundTurnBot.vue
@@ -53,7 +53,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from 'vue'
+import { defineComponent, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
 import NavigationState from '@/util/NavigationState'
@@ -101,16 +101,16 @@ export default defineComponent({
     const { round, turn, turnOrderIndex, action, player, botPass, botActions } = navigationState
     const routeCalculator = new RouteCalculator({round, turn, turnOrderIndex, action, player})
 
+    const botGameBoardResources = ref({} as BotGameBoardResources)
     const isLastRound = (round == 5)
     if (botPass && !isLastRound) {
-      navigationState.botActionResources.applyAction({action:Action.PASS})
+      botGameBoardResources.value = getInitialBotGameBoardResources({action:Action.PASS})
     }
 
-    return { t, router, navigationState, state, routeCalculator, round, turn, turnOrderIndex, botPass, botActions, isLastRound }
+    return { t, router, navigationState, state, routeCalculator, round, turn, turnOrderIndex, botPass, botActions, isLastRound, botGameBoardResources }
   },
   data() {
     return {
-      botGameBoardResources: {} as BotGameBoardResources,
       botGameBoardResourcesUpdateCount: 0,
       actionReady: false,
       actionTechType: undefined as TechType|undefined,

--- a/tests/unit/services/BotActionResources.spec.ts
+++ b/tests/unit/services/BotActionResources.spec.ts
@@ -94,9 +94,7 @@ describe('services/BotActionResources', () => {
     const underTest = new BotActionResources()
     underTest.applyAction({action:Action.PASS})
 
-    expect(underTest.resources).to.eql(resources({
-      progress: 1
-    }))
+    expect(underTest.resources).to.eql(resources({}))
   })
 
   it('apply-alien-special-action-mascamites', () => {

--- a/tests/unit/util/getInitialBotGameBoardResources.spec.ts
+++ b/tests/unit/util/getInitialBotGameBoardResources.spec.ts
@@ -15,6 +15,11 @@ describe('util/getInitialBotGameBoardResources', () => {
     expect(resources).to.eql({data: 3})
   })
 
+  it('pass', () => {
+    const resources = getInitialBotGameBoardResources({action:Action.PASS})
+    expect(resources).to.eql({progressSingleStep: 1})
+  })
+
   it('other', () => {
     const resources = getInitialBotGameBoardResources({action:Action.ANALYZE, victoryPoints: 1}, TechType.COMPUTER)
     expect(resources).to.eql({})


### PR DESCRIPTION
following the rules, the rival always got 1 progress step when passing, because he removed a card from the end-of-round stack.
but this was not visible to the player, although technically the rival has gained this from the _game board_.
to make this more visible, the progress step should be displayed in the gray box.