### PR TITLE
Allow rival to pay data for Centaurians Life Trace spot - improve rules hint

### DIFF
--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -185,7 +185,7 @@
         "centaurians": {
           "title": "Centaurianer Spezial-Aktion",
           "instructions": "Falls der Rivale noch Nachrichten-Meilensteine in seiner Reserve hat und keine auf der Punkteleiste: Platziere 15 Felder vor seinem aktuellen Punktemarker einen Nachrichten-Meilenstein.",
-          "generalInstructions": "Sobald die Centraurianer entdeckt werden, legen du und dein Rivale je einen Nachricht-Meilenstein aus. Außerdem erhält er alle übrigen Nachricht-Meilensteine. Diese kann er mit seiner Spezies-Aktion nutzen.<br/>Dein Rivale besetzt Felder mit Datenkosten nur dann, falls sein Computer bereits voll ist und er genügend Daten besitzt (min. 9 Daten). Trage die Daten-Kosten dann als negativer Wert ein.",
+          "generalInstructions": "Sobald die Centraurianer entdeckt werden, legen du und dein Rivale je einen Nachricht-Meilenstein aus. Außerdem erhält er alle übrigen Nachricht-Meilensteine. Diese kann er mit seiner Spezies-Aktion nutzen.<br/>Dein Rivale besetzt Felder mit Datenkosten nur dann, falls sein Computer bereits voll ist und er genügend Daten besitzt (min. 6 Daten zzgl. der Datenkosten). Trage die Datenkosten dann als negativer Wert ein.",
           "addMilestone": "Füge Nachricht-Meilenstein des Gegners hinzu"
         },
         "exertians": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -185,7 +185,7 @@
         "centaurians": {
           "title": "Centaurians Special Action",
           "instructions": "If the rival still has a message milestone in his reserve and none on the scoring track, place one message milestone 15 points ahead of their current score.",
-          "generalInstructions": "When you discover this alien species, the rival places one message milestone token as a player would, and takes all leftover tokens. They get to use them with their alien action.<br/>The rival marks spaces that require payment of data only if they have a full computer and enough leftover data to pay (min. 9 data). Enter the data cost as negative value.",
+          "generalInstructions": "When you discover this alien species, the rival places one message milestone token as a player would, and takes all leftover tokens. They get to use them with their alien action.<br/>The rival marks spaces that require payment of data only if they have a full computer and enough leftover data to pay (min. 6 data plus the data cost). Enter the data cost as negative value.",
           "addMilestone": "Add Rival Milestone Token"
         },
         "exertians": {


### PR DESCRIPTION
Fixes #23 

* Updated hint for Centaurians rules in species discovery dialog:
_The rival marks spaces that require payment of data only if they have a full computer and enough leftover data to pay **(min. 6 data plus the data cost). Enter the data cost as negative value.**_

Updated i18n keys:
```
rules.action.speciesSpecialAction.centaurians.generalInstructions
```