### PR TITLE
Difficulty Level 4/5: Use correct initial progress setup

### DIFF
--- a/src/util/NavigationState.ts
+++ b/src/util/NavigationState.ts
@@ -79,7 +79,7 @@ function getBotPersistence(state:State, round:number, turn:number, turnOrderInde
     cardDeck: CardDeck.new(state.setup.difficultyLevel).toPersistence(),
     objectiveStack: ObjectiveStack.new(state.setup.difficultyLevel).toPersistence(),
     milestoneTracker: MilestoneTracker.new().toPersistence(),
-    resources: getInitialBotResources(roundData?.startPlayer ?? Player.PLAYER),
+    resources: getInitialBotResources(roundData?.startPlayer ?? Player.PLAYER, state.setup.difficultyLevel),
   }
 }
 

--- a/src/util/getInitialBotResources.ts
+++ b/src/util/getInitialBotResources.ts
@@ -1,3 +1,4 @@
+import DifficultyLevel from '@/services/enum/DifficultyLevel'
 import Player from '@/services/enum/Player'
 import { BotResources } from '@/store/state'
 
@@ -6,9 +7,9 @@ import { BotResources } from '@/store/state'
  * @param startPlayer Start player
  * @returns Bot resources
  */
-export default function(startPlayer: Player) : BotResources {
+export default function(startPlayer: Player, difficultyLevel: DifficultyLevel) : BotResources {
   return {
-    progress: 1,
+    progress: getInitialProgress(difficultyLevel),
     publicity: 4,
     data: 0,
     vp: startPlayer == Player.BOT ? 1 : 2,
@@ -16,5 +17,16 @@ export default function(startPlayer: Player) : BotResources {
     techTelescope: 0,
     techComputer: 0,
     probeCount: 0
+  }
+}
+
+function getInitialProgress(difficultyLevel: DifficultyLevel): number {
+  switch (difficultyLevel) {
+    case DifficultyLevel.LEVEL_4:
+      return 4
+    case DifficultyLevel.LEVEL_5:
+      return 9
+    default:
+      return 1
   }
 }

--- a/src/views/SetupApp.vue
+++ b/src/views/SetupApp.vue
@@ -54,7 +54,7 @@ export default defineComponent({
           cardDeck: CardDeck.new(this.state.setup.difficultyLevel).toPersistence(),
           objectiveStack: ObjectiveStack.new(this.state.setup.difficultyLevel).toPersistence(),
           milestoneTracker: MilestoneTracker.new().toPersistence(),
-          resources: getInitialBotResources(startPlayer)
+          resources: getInitialBotResources(startPlayer, this.state.setup.difficultyLevel)
         },
         turns: []
       }

--- a/tests/unit/util/getInitialBotResources.spec.ts
+++ b/tests/unit/util/getInitialBotResources.spec.ts
@@ -1,19 +1,34 @@
 import { expect } from 'chai'
 import getInitialBotResources from '@/util/getInitialBotResources'
 import Player from '@/services/enum/Player'
+import DifficultyLevel from '@/services/enum/DifficultyLevel'
 
 describe('util/getInitialBotResources', () => {
   it('startplayer-bot', () => {
-    const resources = getInitialBotResources(Player.BOT)
+    const resources = getInitialBotResources(Player.BOT, DifficultyLevel.LEVEL_1)
     expect(resources.progress).to.eq(1)
     expect(resources.publicity).to.eq(4)
     expect(resources.vp).to.eq(1)
   })
 
   it('startplayer-player', () => {
-    const resources = getInitialBotResources(Player.PLAYER)
+    const resources = getInitialBotResources(Player.PLAYER, DifficultyLevel.LEVEL_1)
     expect(resources.progress).to.eq(1)
     expect(resources.publicity).to.eq(4)
     expect(resources.vp).to.eq(2)
+  })
+
+  it('startplayer-bot-level4', () => {
+    const resources = getInitialBotResources(Player.BOT, DifficultyLevel.LEVEL_4)
+    expect(resources.progress).to.eq(4)
+    expect(resources.publicity).to.eq(4)
+    expect(resources.vp).to.eq(1)
+  })
+
+  it('startplayer-bot-level5', () => {
+    const resources = getInitialBotResources(Player.BOT, DifficultyLevel.LEVEL_5)
+    expect(resources.progress).to.eq(9)
+    expect(resources.publicity).to.eq(4)
+    expect(resources.vp).to.eq(1)
   })
 })


### PR DESCRIPTION
as pointed out in [this thread](https://boardgamegeek.com/thread/3548466/solo-mode-setup-question), the initial progress for the rival is not always 1 - actually its different for:
* Difficulty Level 4: step 4
* Difficulty Level 5: step 9